### PR TITLE
Fix: Popover focus handling and screenshot timing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "trackhands"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "objc2 0.6.3",
  "objc2-app-kit",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,10 +177,20 @@ pub fn run() {
 
             let popover_clone = popover.clone();
             popover.on_window_event(move |event| {
-                if let WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    let _ = popover_clone.set_size(tauri::LogicalSize::new(1.0, 1.0));
-                    let _ = popover_clone.set_position(tauri::LogicalPosition::new(0.0, 0.0));
+                match event {
+                    WindowEvent::CloseRequested { api, .. } => {
+                        api.prevent_close();
+                        let _ = popover_clone.set_size(tauri::LogicalSize::new(1.0, 1.0));
+                        let _ = popover_clone.set_position(tauri::LogicalPosition::new(0.0, 0.0));
+                    }
+                    WindowEvent::Focused(false) => {
+                        let size = popover_clone.inner_size().unwrap_or(tauri::PhysicalSize::new(1, 1));
+                        if size.width > MIN_VISIBLE_WIDTH {
+                            let _ = popover_clone.set_size(tauri::LogicalSize::new(1.0, 1.0));
+                            let _ = popover_clone.set_position(tauri::LogicalPosition::new(0.0, 0.0));
+                        }
+                    }
+                    _ => {}
                 }
             });
 


### PR DESCRIPTION
## Changes

### Popover Focus Handling
- Added focus lost event handler to automatically hide the popover when clicking outside of it
- This fixes the issue where the popover would stay visible after clicking elsewhere

### Screenshot Timing
- Delayed screenshot capture until halfway through the warning delay instead of immediately
- This captures a more accurate image when the finger is actually near the mouth
- Added proper ref tracking to prevent multiple screenshots

### Camera Restart
- Fixed camera restart after warning is dismissed
- Now properly stops detection, restarts camera, and resumes detection
- Reset screenshot state properly on detection reset

## Testing
- Tested popover hiding on focus loss
- Verified screenshot timing captures at the right moment
- Confirmed camera restarts correctly after dismissing warning