### PR TITLE
Fix popover visibility tracking

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ src-tauri/target
 pnpm-lock.yaml
 
 
+

--- a/src/hooks/use-detection.ts
+++ b/src/hooks/use-detection.ts
@@ -71,12 +71,7 @@ export function useDetection({
 
         if (timeInMouth >= warningDelayMs && !warningShownRef.current) {
           warningShownRef.current = true;
-
-          const isPopoverVisible = await invoke<boolean>("is_popover_visible").catch(() => false);
-
-          if (!isPopoverVisible) {
-            invoke("show_warning").catch(console.error);
-          }
+          invoke("show_warning").catch(console.error);
         }
       } else {
         fingerInMouthStartRef.current = null;


### PR DESCRIPTION
Replace size-based visibility detection with explicit state tracking using mutexes. Popover now stays open when warning is shown so the user can debug properly.