### PR TITLE
Reduce unnecessary re-renders

### DIFF
--- a/src/components/popover-window/components/camera/camera-with-detection.tsx
+++ b/src/components/popover-window/components/camera/camera-with-detection.tsx
@@ -1,0 +1,27 @@
+import { useDetection } from "@/hooks/use-detection";
+import { useRef } from "react";
+import { Camera } from "./camera";
+
+function DetectionRunner({
+  videoRef,
+  canvasRef,
+}: {
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+}) {
+  useDetection({ videoRef, canvasRef });
+
+  return null;
+}
+
+export function CameraWithDetection() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  return (
+    <>
+      <DetectionRunner videoRef={videoRef} canvasRef={canvasRef} />
+      <Camera videoRef={videoRef} canvasRef={canvasRef} />
+    </>
+  );
+}

--- a/src/components/popover-window/components/camera/camera.tsx
+++ b/src/components/popover-window/components/camera/camera.tsx
@@ -1,26 +1,14 @@
-import { useDetection } from "@/hooks/use-detection";
-import { useAppStore } from "@/stores/app-store";
-import { useEffect, useMemo, useRef } from "react";
+import { OverlayCanvas } from "@/components/popover-window/components/camera/components/overlay-canvas";
+import { useEffect, useRef } from "react";
 import { StatusBadge } from "./components/status-badge";
-import { useDrawOverlay } from "./hooks/use-draw-overlay";
 
-export function Camera() {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+interface CameraProps {
+  videoRef: React.RefObject<HTMLVideoElement>;
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+}
+
+export function Camera({ videoRef, canvasRef }: CameraProps) {
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
-
-  const { mouthRect, handInMouth, warningDelay, detectionElapsed } = useAppStore();
-
-  const status = useMemo(() => {
-    if (!mouthRect) return "off";
-    if (!handInMouth) return "clear";
-    if (detectionElapsed >= warningDelay) return "alert";
-
-    return "warning";
-  }, [mouthRect, handInMouth, warningDelay, detectionElapsed]);
-
-  useDetection({ videoRef, canvasRef });
-  useDrawOverlay({ videoRef, overlayCanvasRef });
 
   useEffect(() => {
     const video = videoRef.current;
@@ -46,7 +34,7 @@ export function Camera() {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, []);
+  }, [videoRef]);
 
   return (
     <div className="relative w-full h-full overflow-hidden bg-surface-alt shadow-app">
@@ -57,20 +45,12 @@ export function Camera() {
         muted
         className="w-full h-full object-cover -scale-x-100"
       />
-      <canvas ref={canvasRef} className="hidden" />
-      <canvas
-        ref={overlayCanvasRef}
-        className="absolute top-0 left-0 w-full h-full pointer-events-none -scale-x-100"
-      />
 
-      <StatusBadge
-        status={status}
-        countdown={
-          handInMouth && detectionElapsed < warningDelay
-            ? (warningDelay - detectionElapsed) / 1000
-            : null
-        }
-      />
+      <canvas ref={canvasRef} className="hidden" />
+
+      <OverlayCanvas videoRef={videoRef} overlayCanvasRef={overlayCanvasRef} />
+
+      <StatusBadge />
     </div>
   );
 }

--- a/src/components/popover-window/components/camera/components/overlay-canvas.tsx
+++ b/src/components/popover-window/components/camera/components/overlay-canvas.tsx
@@ -1,0 +1,18 @@
+import { useDrawOverlay } from "@/components/popover-window/components/camera/hooks/use-draw-overlay";
+
+export function OverlayCanvas({
+  videoRef,
+  overlayCanvasRef,
+}: {
+  videoRef: React.RefObject<HTMLVideoElement>;
+  overlayCanvasRef: React.RefObject<HTMLCanvasElement>;
+}) {
+  useDrawOverlay({ videoRef, overlayCanvasRef });
+
+  return (
+    <canvas
+      ref={overlayCanvasRef}
+      className="absolute top-0 left-0 w-full h-full pointer-events-none -scale-x-100"
+    />
+  );
+}

--- a/src/components/popover-window/popover-window.tsx
+++ b/src/components/popover-window/popover-window.tsx
@@ -1,4 +1,4 @@
-import { Camera } from "@/components/popover-window/components/camera/camera";
+import { CameraWithDetection } from "@/components/popover-window/components/camera/camera-with-detection";
 import { Settings } from "@/components/popover-window/components/settings";
 import { SettingsButton } from "@/components/popover-window/components/settings-button";
 import { WindowControls } from "@/components/popover-window/components/window-controls";
@@ -8,6 +8,7 @@ import { useState } from "react";
 
 export function PopoverWindow() {
   const [showSettings, setShowSettings] = useState(false);
+
   const {
     detectionSpeed,
     cameraResolution,
@@ -30,7 +31,7 @@ export function PopoverWindow() {
   return (
     <div className="flex flex-col h-full p-2 gap-2 bg-surface rounded-2xl overflow-hidden">
       <div className="flex-1 min-h-0 rounded-lg overflow-hidden">
-        <Camera />
+        <CameraWithDetection />
       </div>
 
       {showSettings && (

--- a/src/hooks/use-detection.ts
+++ b/src/hooks/use-detection.ts
@@ -7,6 +7,7 @@ import { detectionIntervals, useAppStore } from "@/stores/app-store";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 export function useDetection({
   videoRef,
@@ -28,7 +29,14 @@ export function useDetection({
   } = useMediaPipe();
   const { start: startCamera, stop: stopCamera, isActive: isCameraActive } = useCamera(videoRef);
 
-  const { setHandInMouth, setMouthRect, setFingerPositions, setDetectionElapsed } = useAppStore();
+  const { setHandInMouth, setMouthRect, setFingerPositions, setDetectionElapsed } = useAppStore(
+    useShallow((state) => ({
+      setHandInMouth: state.setHandInMouth,
+      setMouthRect: state.setMouthRect,
+      setFingerPositions: state.setFingerPositions,
+      setDetectionElapsed: state.setDetectionElapsed,
+    }))
+  );
 
   const screenshotTakenRef = useRef<boolean>(false);
 

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,6 +1,7 @@
 import { useAppStore, type DetectionSpeed } from "@/stores/app-store";
 import { load, type Store } from "@tauri-apps/plugin-store";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useShallow } from "zustand/shallow";
 
 export function useSettings() {
   const {
@@ -12,7 +13,19 @@ export function useSettings() {
     setCameraResolution,
     setWarningDelay,
     setAutoDismissDelay,
-  } = useAppStore();
+  } = useAppStore(
+    useShallow((state) => ({
+      detectionSpeed: state.detectionSpeed,
+      cameraResolution: state.cameraResolution,
+      warningDelay: state.warningDelay,
+      autoDismissDelay: state.autoDismissDelay,
+      setDetectionSpeed: state.setDetectionSpeed,
+      setCameraResolution: state.setCameraResolution,
+      setWarningDelay: state.setWarningDelay,
+      setAutoDismissDelay: state.setAutoDismissDelay,
+    }))
+  );
+
   const storeRef = useRef<Store | null>(null);
 
   useEffect(() => {
@@ -49,37 +62,53 @@ export function useSettings() {
     loadSettings();
   }, [setDetectionSpeed, setCameraResolution, setWarningDelay, setAutoDismissDelay]);
 
-  const saveDetectionSpeed = async (speed: DetectionSpeed) => {
-    setDetectionSpeed(speed);
-    if (storeRef.current) {
-      await storeRef.current.set("detectionSpeed", speed);
-      await storeRef.current.save();
-    }
-  };
+  const saveDetectionSpeed = useCallback(
+    async (speed: DetectionSpeed) => {
+      setDetectionSpeed(speed);
 
-  const saveCameraResolution = async (resolution: "low" | "medium" | "high") => {
-    setCameraResolution(resolution);
-    if (storeRef.current) {
-      await storeRef.current.set("cameraResolution", resolution);
-      await storeRef.current.save();
-    }
-  };
+      if (storeRef.current) {
+        await storeRef.current.set("detectionSpeed", speed);
+        await storeRef.current.save();
+      }
+    },
+    [setDetectionSpeed]
+  );
 
-  const saveWarningDelay = async (delay: number) => {
-    setWarningDelay(delay);
-    if (storeRef.current) {
-      await storeRef.current.set("warningDelay", delay);
-      await storeRef.current.save();
-    }
-  };
+  const saveCameraResolution = useCallback(
+    async (resolution: "low" | "medium" | "high") => {
+      setCameraResolution(resolution);
 
-  const saveAutoDismissDelay = async (delay: number) => {
-    setAutoDismissDelay(delay);
-    if (storeRef.current) {
-      await storeRef.current.set("autoDismissDelay", delay);
-      await storeRef.current.save();
-    }
-  };
+      if (storeRef.current) {
+        await storeRef.current.set("cameraResolution", resolution);
+        await storeRef.current.save();
+      }
+    },
+    [setCameraResolution]
+  );
+
+  const saveWarningDelay = useCallback(
+    async (delay: number) => {
+      setWarningDelay(delay);
+
+      if (storeRef.current) {
+        await storeRef.current.set("warningDelay", delay);
+        await storeRef.current.save();
+      }
+    },
+    [setWarningDelay]
+  );
+
+  const saveAutoDismissDelay = useCallback(
+    async (delay: number) => {
+      setAutoDismissDelay(delay);
+
+      if (storeRef.current) {
+        await storeRef.current.set("autoDismissDelay", delay);
+        await storeRef.current.save();
+      }
+    },
+    [setAutoDismissDelay]
+  );
 
   return {
     detectionSpeed,


### PR DESCRIPTION
Use `useShallow` selectors and isolate components to prevent cascading re-renders when store state changes and separate components that are updated on every frame.