### PR TITLE
Fix warning window autofocus

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "trackhands"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "image",
  "objc2 0.6.3",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,9 +36,15 @@ fn show_warning(app: AppHandle) {
         let _ = warning.show();
     }
 
-    if POPOVER_VISIBLE.lock().map(|g| *g).unwrap_or(false) {
+    let popover_visible = POPOVER_VISIBLE.lock().map(|g| *g).unwrap_or(false);
+
+    if popover_visible {
         if let Some(popover) = app.get_webview_window("popover") {
             let _ = popover.set_focus();
+        }
+    } else {
+        if let Some(warning) = app.get_webview_window("warning") {
+            let _ = warning.set_focus();
         }
     }
 


### PR DESCRIPTION
When the warning overlay is triggered and the popover window is closed, focus the warning window so users can click the dismiss button immediately without needing to click twice (once to focus, once to press).

Fixes #8