### PR TITLE
fix: restore focus to previous window on warning dismiss

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,6 @@ tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSRunningApplication", "NSWorkspace"] }
 objc2-foundation = "0.3"
 


### PR DESCRIPTION
When the warning overlay is dismissed, focus is now restored to the window/application that was focused before the warning appeared.

Closes #12