### PR TITLE
feat: add privacy policy page

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,8 @@
     "@tailwindcss/vite": "^4.1.18",
     "hugeicons-react": "^0.3.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "wouter": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
+      wouter:
+        specifier: ^3.8.1
+        version: 3.8.1(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -1072,6 +1075,9 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1141,6 +1147,10 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1228,6 +1238,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite@7.2.7:
     resolution: {integrity: sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1276,6 +1291,11 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wouter@3.8.1:
+    resolution: {integrity: sha512-4rIFV23qZqFMfiZ2jrLPsABULZGyogmU8TRWN3jJoPa+8izkQcWQ6zV5ZJFp/Ky9D6Zpt1mOHOqL9FHbOO3DNA==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2217,6 +2237,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  mitt@3.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2272,6 +2294,8 @@ snapshots:
   react-refresh@0.18.0: {}
 
   react@19.2.3: {}
+
+  regexparam@3.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -2365,6 +2389,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   vite@7.2.7(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.25.12
@@ -2384,6 +2412,13 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  wouter@3.8.1(react@19.2.3):
+    dependencies:
+      mitt: 3.0.1
+      react: 19.2.3
+      regexparam: 3.0.0
+      use-sync-external-store: 1.6.0(react@19.2.3)
 
   yallist@3.1.1: {}
 

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,16 +1,14 @@
-import { Features, Footer, Hero, HowItWorks, Navbar, Privacy } from "./components";
+import { Route, Switch } from "wouter";
+import { HomePage, PrivacyPolicyPage } from "./pages";
 
 function App() {
   return (
     <div className="min-h-screen bg-surface">
       <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,#2d2d2d_0%,#1a1a1a_50%)] pointer-events-none" />
-      <Navbar />
-      <Hero />
-      <Features />
-      <HowItWorks />
-      <Privacy />
-
-      <Footer />
+      <Switch>
+        <Route path="/" component={HomePage} />
+        <Route path="/privacy" component={PrivacyPolicyPage} />
+      </Switch>
     </div>
   );
 }

--- a/site/src/components/footer.tsx
+++ b/site/src/components/footer.tsx
@@ -1,3 +1,5 @@
+import { Link } from "wouter";
+
 export function Footer() {
   return (
     <footer className="relative py-6 px-6 sm:px-10 lg:px-4 border-t border-white/5">
@@ -24,9 +26,14 @@ export function Footer() {
           >
             Releases
           </a>
+          <Link
+            href="/privacy"
+            className="text-xs text-muted hover:text-foreground transition-colors"
+          >
+            Privacy
+          </Link>
         </div>
       </div>
     </footer>
   );
 }
-

--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -1,17 +1,29 @@
+import { Link } from "wouter";
+import { GitHubIcon } from "./github-icon";
+
 export function Navbar() {
   return (
     <nav className="relative px-6 sm:px-10 lg:px-4 py-4">
       <div className="max-w-5xl mx-auto flex items-center justify-between">
-        <div className="flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
           <img src="/icon.png" alt="TrackHands" className="w-6 h-6 rounded-md" />
           <span className="font-semibold text-sm">TrackHands</span>
+        </Link>
+        <div className="flex items-center gap-2">
+          <a
+            href="https://github.com/cacoos/trackhands"
+            className="p-1.5 text-muted hover:text-foreground transition-colors"
+            aria-label="GitHub"
+          >
+            <GitHubIcon size={16} />
+          </a>
+          <a
+            href="https://github.com/cacoos/trackhands/releases/latest"
+            className="px-3 py-1.5 bg-foreground text-surface rounded-md font-medium text-xs hover:bg-foreground/90 transition-colors"
+          >
+            Download
+          </a>
         </div>
-        <a
-          href="https://github.com/cacoos/trackhands/releases/latest"
-          className="px-4 py-2 bg-foreground text-surface rounded-lg font-medium text-sm hover:bg-foreground/90 transition-colors"
-        >
-          Download
-        </a>
       </div>
     </nav>
   );

--- a/site/src/pages/home.tsx
+++ b/site/src/pages/home.tsx
@@ -1,0 +1,14 @@
+import { Features, Footer, Hero, HowItWorks, Navbar, Privacy } from "../components";
+
+export function HomePage() {
+  return (
+    <>
+      <Navbar />
+      <Hero />
+      <Features />
+      <HowItWorks />
+      <Privacy />
+      <Footer />
+    </>
+  );
+}

--- a/site/src/pages/index.ts
+++ b/site/src/pages/index.ts
@@ -1,0 +1,3 @@
+export { HomePage } from "./home";
+export { PrivacyPolicyPage } from "./privacy-policy";
+

--- a/site/src/pages/privacy-policy.tsx
+++ b/site/src/pages/privacy-policy.tsx
@@ -1,0 +1,132 @@
+import { Footer, Navbar } from "../components";
+
+export function PrivacyPolicyPage() {
+  return (
+    <>
+      <Navbar />
+
+      <main className="relative pt-12 pb-12 px-6 sm:px-10 lg:px-4">
+        <article className="max-w-5xl mx-auto">
+          <h1 className="text-2xl font-display font-semibold mb-2">Privacy Policy</h1>
+          <p className="text-muted text-sm mb-8">Last updated: December 14, 2025</p>
+
+          <div className="space-y-8 text-sm leading-relaxed">
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Overview</h2>
+              <p className="text-muted">
+                TrackHands is designed with privacy as a core principle. The app runs entirely on
+                your device, and we do not collect, store, or transmit any of your data.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">What the App Accesses</h2>
+              <p className="text-muted mb-3">
+                TrackHands requires access to your camera to function. This access is used to:
+              </p>
+              <ul className="list-disc list-inside text-muted space-y-1 ml-2">
+                <li>Detect your face and hand positions in real-time</li>
+                <li>Determine when your fingers are near your mouth</li>
+                <li>Display a warning overlay when this behavior is detected</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">How Your Data is Handled</h2>
+              <ul className="list-disc list-inside text-muted space-y-1 ml-2">
+                <li>
+                  <strong className="text-foreground">Local Processing:</strong> All camera
+                  processing happens locally on your device using MediaPipe. Your camera feed is
+                  never transmitted over the internet.
+                </li>
+                <li>
+                  <strong className="text-foreground">No Cloud Services:</strong> TrackHands does
+                  not connect to any external servers or cloud services.
+                </li>
+                <li>
+                  <strong className="text-foreground">No Analytics:</strong> We do not collect usage
+                  statistics, crash reports, or any other telemetry data.
+                </li>
+                <li>
+                  <strong className="text-foreground">No Accounts:</strong> The app does not require
+                  registration or any personal information.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">What is Stored Locally</h2>
+              <p className="text-muted mb-3">
+                The following data is stored locally on your device:
+              </p>
+              <ul className="list-disc list-inside text-muted space-y-1 ml-2">
+                <li>
+                  <strong className="text-foreground">Settings:</strong> Your preferences (detection
+                  speed, camera resolution) are saved in local storage.
+                </li>
+                <li>
+                  <strong className="text-foreground">Screenshots:</strong> When a detection occurs,
+                  a screenshot may be saved to help you build awareness. These images are stored
+                  only on your device and are never uploaded anywhere.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Open Source</h2>
+              <p className="text-muted">
+                TrackHands is open source software licensed under the MIT License. You can review
+                the complete source code on{" "}
+                <a
+                  href="https://github.com/cacoos/trackhands"
+                  className="text-accent hover:underline"
+                >
+                  GitHub
+                </a>{" "}
+                to verify these privacy claims for yourself.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Third-Party Services</h2>
+              <p className="text-muted">
+                TrackHands uses MediaPipe, a machine learning library by Google, for hand and face
+                detection. MediaPipe runs entirely on your device—no data is sent to Google or any
+                other third party.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Changes to This Policy</h2>
+              <p className="text-muted">
+                If we make changes to this privacy policy, we will update the "Last updated" date at
+                the top of this page. Since the app has no update mechanism that collects data, you
+                can always check the latest version of this policy on our website.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold mb-3">Contact</h2>
+              <p className="text-muted">
+                If you have any questions about this privacy policy, you can reach out on{" "}
+                <a href="https://x.com/cacoos" className="text-accent hover:underline">
+                  X (@cacoos)
+                </a>{" "}
+                or open an issue on{" "}
+                <a
+                  href="https://github.com/cacoos/trackhands/issues"
+                  className="text-accent hover:underline"
+                >
+                  GitHub
+                </a>
+                .
+              </p>
+            </section>
+          </div>
+        </article>
+      </main>
+
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a privacy policy page to the landing site with client-side routing.

## Changes

- **Routing** — Added wouter for lightweight client-side routing
- **Privacy Policy page** — New `/privacy` route with comprehensive privacy policy covering data handling, local processing, and open source transparency
- **Navigation updates** — Footer now includes Privacy link, navbar logo links to home
- **Navbar improvements** — Added GitHub icon, made Download button smaller
- **Page structure** — Refactored into pages folder (`home.tsx`, `privacy-policy.tsx`) for better organization